### PR TITLE
Cloudevent all the things

### DIFF
--- a/ert_shared/ensemble_evaluator/entity/ensemble.py
+++ b/ert_shared/ensemble_evaluator/entity/ensemble.py
@@ -1,9 +1,14 @@
+from ert_shared.ensemble_evaluator.entity.snapshot import Snapshot
+
 class _Ensemble:
     def __init__(self, data):
-        self._data = data
+        self._data = Snapshot(data)
+
+    def evaluate(self, host, port):
+        pass
 
     def snapshot(self):
-        return self.to_dict()
+        return self._data
 
     def to_dict(self):
         return self._data

--- a/ert_shared/ensemble_evaluator/entity/ensemble_response_event.py
+++ b/ert_shared/ensemble_evaluator/entity/ensemble_response_event.py
@@ -1,6 +1,5 @@
 from ert_shared.ensemble_evaluator.entity import identifiers as ids
 from ert_shared.ensemble_evaluator.entity.tool import recursive_update
-from ert_shared.ensemble_evaluator.entity.forward_model_job import _ForwardModelJob
 
 
 class _EnsembleResponseEvent:

--- a/ert_shared/ensemble_evaluator/entity/identifiers.py
+++ b/ert_shared/ensemble_evaluator/entity/identifiers.py
@@ -26,6 +26,10 @@ EVTYPE_FM_STEP_START = "com.equinor.ert.forward_model_step.start"
 EVTYPE_FM_STEP_FAILURE = "com.equinor.ert.forward_model_step.failure"
 EVTYPE_FM_STEP_SUCCESS = "com.equinor.ert.forward_model_step.success"
 
+EVTYPE_EE_SNAPSHOT_UPDATE = "com.equinor.ert.ee.snapshot_update"
+EVTYPE_EE_TERMINATED = "com.equinor.ert.ee.terminated"
+EVTYPE_EE_TERMINATE_REQUEST = "com.equinor.ert.ee.terminate_request"
+
 FM_JOB_ATTR_NAME = "name"
 FM_JOB_ATTR_EXECUTABLE = "executable"
 FM_JOB_ATTR_TARGET_FILE = "target_file"

--- a/ert_shared/ensemble_evaluator/entity/snapshot.py
+++ b/ert_shared/ensemble_evaluator/entity/snapshot.py
@@ -1,0 +1,13 @@
+from ert_shared.ensemble_evaluator.entity.tool import recursive_update
+
+
+class Snapshot:
+
+    def __init__(self, dict):
+        self._data = dict
+
+    def merge_event(self, event):
+        recursive_update(self._data, event)
+
+    def to_dict(self):
+        return self._data

--- a/tests/ensemble_evaluator/test_ensemble_evaluator.py
+++ b/tests/ensemble_evaluator/test_ensemble_evaluator.py
@@ -2,9 +2,10 @@ from cloudevents.http import to_json
 from cloudevents.http.event import CloudEvent
 from ert_shared.ensemble_evaluator.evaluator import (
     EnsembleEvaluator,
-    ee_entity,
     ee_monitor,
 )
+from ert_shared.ensemble_evaluator.entity.ensemble import _Ensemble
+import ert_shared.ensemble_evaluator.entity.identifiers as identifiers
 import websockets
 import pytest
 import asyncio
@@ -14,7 +15,42 @@ import json
 
 @pytest.fixture
 def evaluator(unused_tcp_port):
-    ee = EnsembleEvaluator(port=unused_tcp_port)
+    ensemble = _Ensemble({
+            "status": "unknown",
+            "reals": {
+                "0": {
+                    "stages": {
+                        "0": {
+                            "steps": {
+                                "0": {
+                                    "jobs": {
+                                        "0": {
+                                            "status": "unknown"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "1": {
+                    "stages": {
+                        "0": {
+                            "steps": {
+                                "0": {
+                                    "jobs": {
+                                        "0": {
+                                            "status": "unknown"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        })
+    ee = EnsembleEvaluator(ensemble=ensemble, port=unused_tcp_port)
     yield ee
     print("fixture exit")
     ee.stop()
@@ -74,39 +110,41 @@ def test_dispatchers_can_connect_and_monitor_can_shut_down_evaluator(evaluator):
     events = monitor.track()
 
     # first snapshot before any event occurs
-    snapshot = next(events)
-    assert snapshot.to_dict()["status"] == "unknown"
+    snapshot_event = next(events)
+    snapshot = snapshot_event.data
+    assert snapshot["status"] == "unknown"
 
     # two dispatchers connect
     with Client(evaluator._host, evaluator._port, "/dispatch") as dispatch1, Client(evaluator._host, evaluator._port, "/dispatch") as dispatch2:
 
-        # first dispatcher informs that job 1 is running
-        send_dispatch_event(dispatch1, ee_entity._FM_JOB_RUNNING,
-        "/ert/ee/0/real/0/stage/0/step/0/job/1", "event1", {"current_memory_usage": 1000})
-        connect1 = next(events).to_dict()
-        assert connect1["status"] == "running"
-        assert connect1["realizations"]["0"]["status"] == "running"
-        return
-        # second dispatcher informs that job 1 is running
-        send_dispatch_event(dispatch2, realization=1, job=1, status="running")
-        connect2 = next(events).to_dict()
-        assert connect2["status"] == "running"
-        assert connect2["realizations"]["1"]["forward_models"]["1"]["status"] == "running"
+        # first dispatcher informs that job 0 is running
+        send_dispatch_event(dispatch1, identifiers.EVTYPE_FM_JOB_RUNNING,
+            "/ert/ee/0/real/0/stage/0/step/0/job/0", "event1", {"current_memory_usage": 1000})
+        event1 = next(events)
+        connect1 = event1.data
+        assert connect1["reals"]["0"]["stages"]["0"]["steps"]["0"]["jobs"]["0"]["status"] == "running"
 
-        # second dispatcher informs that job 1 is done
-        send_dispatch_event(dispatch2, realization=1, job=1, status="done")
-        connect2 = next(events).to_dict()
-        assert connect2["status"] == "running"
-        assert connect2["realizations"]["1"]["forward_models"]["1"]["status"] == "done"
+        # second dispatcher informs that job 0 is running
+        send_dispatch_event(dispatch2, identifiers.EVTYPE_FM_JOB_RUNNING,
+            "/ert/ee/0/real/1/stage/0/step/0/job/0", "event1", {"current_memory_usage": 1000})
+        connect2 = next(events).data
+        assert connect2["reals"]["1"]["stages"]["0"]["steps"]["0"]["jobs"]["0"]["status"] == "running"
+
+        # second dispatcher informs that job 0 is done
+        send_dispatch_event(dispatch2, identifiers.EVTYPE_FM_JOB_SUCCESS,
+            "/ert/ee/0/real/1/stage/0/step/0/job/0", "event1", {"current_memory_usage": 1000})
+        event3 = next(events)
+        connect3 = event3.data
+        assert connect3["reals"]["1"]["stages"]["0"]["steps"]["0"]["jobs"]["0"]["status"] == "done"
 
         # a second monitor connects
         monitor2 = ee_monitor.create(evaluator._host, evaluator._port)
         events2 = monitor2.track()
-        snapshot2 = next(events2).to_dict()
+        snapshot2 = next(events2).data
         # second monitor should get the updated snapshot
-        assert snapshot2["status"] == "running"
-        assert snapshot2["realizations"]["0"]["forward_models"]["1"]["status"] == "running"
-        assert snapshot2["realizations"]["1"]["forward_models"]["1"]["status"] == "done"
+        assert snapshot2["status"] == "unknown"
+        assert snapshot2["reals"]["0"]["stages"]["0"]["steps"]["0"]["jobs"]["0"]["status"] == "running"
+        assert snapshot2["reals"]["1"]["stages"]["0"]["steps"]["0"]["jobs"]["0"]["status"] == "done"
 
         # one monitor requests that server exit
         monitor.exit_server()
@@ -114,8 +152,8 @@ def test_dispatchers_can_connect_and_monitor_can_shut_down_evaluator(evaluator):
         # both monitors should get a terminated event
         terminated = next(events)
         terminated2 = next(events2)
-        assert terminated.to_dict()["status"] == "terminated"
-        assert terminated2.to_dict()["status"] == "terminated"
+        assert terminated["type"] == identifiers.EVTYPE_EE_TERMINATED
+        assert terminated2["type"] == identifiers.EVTYPE_EE_TERMINATED
 
 
 def test_monitor_stop(evaluator):


### PR DESCRIPTION
Use also cloudevents between evaluator and monitor, allthough of a
different type. This is nice, so we can differentiate between events
that are about snapshot updates, and about other things, like
terminate events.

Code is a mess though
 Couldn't push to @jondequinor  branch, so created a PR